### PR TITLE
feat(fetcher): api updates for 1.0 release

### DIFF
--- a/.changeset/tame-rivers-itch.md
+++ b/.changeset/tame-rivers-itch.md
@@ -1,0 +1,24 @@
+---
+"@labdigital/graphql-fetcher": major
+---
+
+Major API update
+
+## Background
+
+Current versions had some inconsistencies in the API and a few bugs related to persisted queries if they would fail.
+They would also trigger a lot of Next.js errors during development as we force both revalidate to 0 and cache to `no-cache`.
+
+To make error usage more consistent we'll just throw if fetching fails or parsing of JSON fails. Any other errors (like GraphQL body errors) need to be handled by the consumer package.
+There are also no longer any event hooks available as the only one current in use (`beforeRequest`) could just as well be run before calling the fetcher.
+
+## Breaking changes
+
+- initServerFetcher() options `disableCache` has been renamed to `dangerouslyDisableCache` because it can be dangerous when enabled in production
+- Server fetcher params now use a single object for cache and next options instead of positional arguments
+	- e.g. `{ cache: "force-cache", next: { revalidate: 900 }}`
+- Server fetcher default fetch cache option has been changed (`"force-cache"` -> `"default"`)
+- Server fetcher with dangerouslyDisableCache will now set `cache: "no-store"` and remove the revalidate key from the next object as to not trigger warnings and errors in Next.js
+- Client fetcher option has been renamed (`persisted` -> `persistedQueries`)
+- Client fetcher option `onBeforeRequest` has been removed, package consumers will have to run their own function before starting the fetch
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.DS_Store

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,3 @@
+interface RequestInit {
+	next?: NextFetchRequestConfig | undefined;
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "tsup",
+		"build": "tsup --env.PACKAGE_VERSION $(jq -r '.version' package.json)",
 		"publish:ci": "pnpm build && pnpm changeset publish",
 		"test": "vitest run",
 		"test:ci": "vitest run --coverage",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -121,10 +121,25 @@ describe("gqlClientFetch", () => {
 		// Should do two calls, a GET and a POST request
 		expect(mockedFetch).toHaveBeenCalledTimes(2);
 	});
+	// This seems as if we test fetch itself but we're actually testing whether the fetcher properly propagates the fetch errors to the package consumers
 	it("should throw when JSON can't be parsed", () => {
 		fetchMock.mockResponse("<p>Not JSON</p>");
 
 		const gqlResponse = fetcher(query, { myVar: "baz" });
+
+		expect(gqlResponse).rejects.toThrow();
+	});
+	it("should not fallback to POST if the persisted query cannot be parsed", async () => {
+		fetchMock.mockResponse("<p>Not JSON</p>");
+
+		const gqlResponse = persistedFetcher(query, { myVar: "baz" });
+
+		expect(gqlResponse).rejects.toThrow();
+	});
+	it("should not fallback to POST if the persisted query returns an error from the server", async () => {
+		fetchMock.mockReject(new Error("Network error"));
+
+		const gqlResponse = persistedFetcher(query, { myVar: "baz" });
 
 		expect(gqlResponse).rejects.toThrow();
 	});

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -35,6 +35,9 @@ describe("gqlClientFetch", () => {
 	beforeEach(() => fetchMock.resetMocks());
 
 	const fetcher = initClientFetcher("https://localhost/graphql");
+	const persistedFetcher = initClientFetcher("https://localhost/graphql", {
+		persistedQueries: true,
+	});
 
 	it("should perform a query", async () => {
 		const mockedFetch = fetchMock.mockResponse(responseString);
@@ -61,6 +64,28 @@ describe("gqlClientFetch", () => {
 		);
 	});
 
+	it("should perform a persisted query when enabled", async () => {
+		const mockedFetch = fetchMock.mockResponse(responseString);
+
+		const gqlResponse = await persistedFetcher(query, {
+			myVar: "baz",
+		});
+
+		expect(gqlResponse).toEqual(response);
+		expect(mockedFetch).toHaveBeenCalledWith(
+			// When persisted queries are enabled, we suffix all the variables and extensions as search parameters
+			"https://localhost/graphql?op=myQuery&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22e5276e0694f661ef818210402d06d249625ef169a1c2b60383acb2c42d45f7ae%22%7D%7D&variables=%7B%22myVar%22%3A%22baz%22%7D",
+			{
+				// Query is persisted, uses GET to be cached by CDN
+				method: "GET",
+				// These exact headers should be set:
+				credentials: "include",
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+	});
 	it("should perform a mutation", async () => {
 		const mockedFetch = fetchMock.mockResponse(responseString);
 		const gqlResponse = await fetcher(mutation, {
@@ -73,5 +98,34 @@ describe("gqlClientFetch", () => {
 			"https://localhost/graphql?op=myMutation",
 			expect.anything() // <- body, method, headers, etc, are tested in the above
 		);
+	});
+
+	it("should throw when fetch fails", () => {
+		fetchMock.mockReject(new Error("Network error"));
+
+		expect(fetcher(query, { myVar: "baz" })).rejects.toThrow("Network error");
+	});
+	it("should fallback to POST when persisted query is not found on the server", async () => {
+		const mockedFetch = fetchMock.mockResponses(
+			JSON.stringify({
+				errors: [{ message: "PersistedQueryNotFound" }],
+			}),
+			responseString
+		);
+
+		const gqlResponse = await persistedFetcher(query, {
+			myVar: "baz",
+		});
+
+		expect(gqlResponse).toEqual(response);
+		// Should do two calls, a GET and a POST request
+		expect(mockedFetch).toHaveBeenCalledTimes(2);
+	});
+	it("should throw when JSON can't be parsed", () => {
+		fetchMock.mockResponse("<p>Not JSON</p>");
+
+		const gqlResponse = fetcher(query, { myVar: "baz" });
+
+		expect(gqlResponse).rejects.toThrow();
 	});
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,13 +11,7 @@ import {
 	hasPersistedQueryError,
 } from "./helpers";
 
-type RequestEventFn = () => Promise<void>;
-
 type Options = {
-	/**
-	 * Function that runs before a request is being made, useful for tracking or refreshing tokens
-	 */
-	onBeforeRequest?: RequestEventFn;
 	/**
 	 * Enable use of persisted queries, this will always add a extra roundtrip to the server if queries aren't cacheable
 	 * @default false
@@ -33,7 +27,7 @@ export type ClientFetcher = <TResponse, TVariables>(
 export const initClientFetcher =
 	(
 		endpoint: string,
-		{ onBeforeRequest, persistedQueries = false }: Options = {}
+		{ persistedQueries = false }: Options = {}
 	): ClientFetcher =>
 	/**
 	 * Executes a GraphQL query post request on the client.
@@ -60,11 +54,6 @@ export const initClientFetcher =
 					sha256Hash: hash,
 				},
 			};
-		}
-
-		// TODO: Not sure if we want this single event function if it can also be run before running the fetcher
-		if (onBeforeRequest) {
-			await onBeforeRequest();
 		}
 
 		const url = new URL(endpoint);

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,6 @@ export const initClientFetcher =
 			);
 		}
 
-		// TODO: Optimise this flow as you always parse the response twice now when persisted queries are enabled
 		if (!response || hasPersistedQueryError(response)) {
 			// Persisted query not used or found, fall back to POST request and include extension to cache the query on the server
 			response = await parseResponse<GqlResponse<TResponse>>(() =>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,4 @@
 import { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
-import invariant from "tiny-invariant";
 
 export const extractOperationName = (query: string) => {
 	const matches = query.match(/(query|mutation)\s(\w+)/);
@@ -56,24 +55,6 @@ export const createSha256 = async (message: string) => {
 };
 
 /**
- * Helper function that parses the response body and returns the data or throws an error.
- * @param response Fetch response object
- * @returns GraphQL response body
- */
-export const handleResponse = async (response: Response) => {
-	invariant(
-		response.ok,
-		`Response not ok: ${response.status} ${response.statusText}`
-	);
-
-	const body = await response
-		.json()
-		.catch((err) => invariant(false, "Could not parse JSON from response"));
-
-	return body;
-};
-
-/**
  * Check if the response has a PersistedQueryNotFound error.
  * @param response Fetch response object
  */
@@ -90,3 +71,5 @@ export const hasPersistedQueryError = async <T>(response: Response) => {
 		return false;
 	}
 };
+
+export const errorMessage = (message: string) => `graphql-fetcher: ${message}`;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -58,20 +58,11 @@ export const createSha256 = async (message: string) => {
  * Check if the response has a PersistedQueryNotFound error.
  * @param response Fetch response object
  */
-export const hasPersistedQueryError = async <T>(response: Response) => {
-	if (!response.ok) return false;
-
-	try {
-		// Clone response as we can only read the body once, and it will also be read later on in the flow
-		// TODO: Optimise this flow as you always parse the response twice now when persisted queries are enabled
-		const body = (await response.clone().json()) as GqlResponse<T>;
-
-		return Boolean(
-			body?.errors?.find((item) => item.message === "PersistedQueryNotFound")
-		);
-	} catch (err) {
-		return false;
-	}
-};
+export const hasPersistedQueryError = (
+	response: GqlResponse<unknown>
+): boolean =>
+	Boolean(
+		response?.errors?.find((item) => item.message === "PersistedQueryNotFound")
+	);
 
 export const errorMessage = (message: string) => `graphql-fetcher: ${message}`;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -62,7 +62,9 @@ export const hasPersistedQueryError = async <T>(response: Response) => {
 	if (!response.ok) return false;
 
 	try {
-		const body = (await response.json()) as GqlResponse<T>;
+		// Clone response as we can only read the body once, and it will also be read later on in the flow
+		// TODO: Optimise this flow as you always parse the response twice now when persisted queries are enabled
+		const body = (await response.clone().json()) as GqlResponse<T>;
 
 		return Boolean(
 			body?.errors?.find((item) => item.message === "PersistedQueryNotFound")

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -150,4 +150,28 @@ describe("gqlServerFetch", () => {
 			cache: "no-store",
 		});
 	});
+	// This seems as if we test fetch itself but we're actually testing whether the fetcher properly propagates the fetch errors to the package consumers
+	it("should throw when JSON can't be parsed", async () => {
+		const gqlServerFetch = initServerFetcher("https://localhost/graphql");
+		fetchMock.mockResponse("<p>Not JSON</p>");
+
+		await expect(() =>
+			gqlServerFetch(query, { myVar: "baz" }, {})
+		).rejects.toThrow();
+
+		// It should not try to POST the query if the persisted query cannot be parsed
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("should throw when the server response is not ok", async () => {
+		const gqlServerFetch = initServerFetcher("https://localhost/graphql");
+		fetchMock.mockReject(new Error("Network error"));
+
+		await expect(() =>
+			gqlServerFetch(query, { myVar: "baz" }, {})
+		).rejects.toThrow();
+
+		// It should not try to POST the query if the persisted query cannot be parsed
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,11 +31,11 @@ const tracer = trace.getTracer(
 );
 
 export const initServerFetcher =
-	(url: string, { dangerouslyDisableCache = false }: Options) =>
+	(url: string, { dangerouslyDisableCache = false }: Options = {}) =>
 	async <TResponse, TVariables>(
 		astNode: DocumentTypeDecoration<TResponse, TVariables>,
 		variables: TVariables,
-		{ cache = "force-cache", next = {} }: CacheOptions
+		{ cache = "default", next = {} }: CacheOptions
 	): Promise<GqlResponse<TResponse>> => {
 		const query = astNode.toString();
 		const operationName = extractOperationName(query) || "(GraphQL)";


### PR DESCRIPTION
General update of the fetcher codebase:
- No more mixing of async/await and Promise.then()
- More freedom in error handling on GraphQL body errors using an `errorPolicy` option
- Next and cache options for fetch can now be set in an object instead of positional arguments, you no longer need to set the cache option if you want to add next options
- Disabling the cache no longer sets revalidate to 0, this removes constant error messages in Next.js
- Renamed `disableCache` to `dangerouslyDisableCache` as this should only be used with care
- Set package version for tracer during build time
- Add `NextFetchConfig` to `RequestInit` to extend `fetch()` with all the Next.js fields
- Prefix error messages so it's clear where the errors originate from

Note: This PR contains breaking changes and should only be released with a major release

Breaking changes:
- `initServerFetcher()` options `disableCache` has been renamed to `dangerouslyDisableCache`
- Server fetcher params now use a single object for `cache` and `next` options instead of positional arguments
- Server fetcher default fetch cache option has been changed from `force-cache` to `default`
- Server fetcher with `dangerouslyDisableCache` will now set `cache: "no-store"` and remove the `revalidate` key from the next object as to not trigger warnings and errors in Next.js
- Client fetcher option `persisted` has been renamed to `persistedQueries`
- Client fetcher option `onBeforeRequest` has been removed, package consumers will have to run their own function before starting the fetch
