### PR TITLE
fix(server): cache props

### DIFF
--- a/.changeset/selfish-otters-tap.md
+++ b/.changeset/selfish-otters-tap.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": patch
+---
+
+add correct cache property

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -86,7 +86,6 @@ describe("gqlServerFetch", () => {
 				headers: {
 					"Content-Type": "application/json",
 				},
-				cache: "default",
 				next: { revalidate: 900 },
 			}
 		);

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,7 +35,7 @@ export const initServerFetcher =
 	async <TResponse, TVariables>(
 		astNode: DocumentTypeDecoration<TResponse, TVariables>,
 		variables: TVariables,
-		{ cache = "default", next = {} }: CacheOptions
+		{ cache, next = {} }: CacheOptions
 	): Promise<GqlResponse<TResponse>> => {
 		const query = astNode.toString();
 		const operationName = extractOperationName(query) || "(GraphQL)";


### PR DESCRIPTION
## Context

The cache header always defaults to cache: default, meaning you get errors when using it in combination with revalidate.

## Changes

- Removed the default value

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code for breaking changes and added the corresponding footer in this PR if needed
- [x] I have added tests that prove my fix is effective or that my feature works
