### PR TITLE
feat: skip persisted queries for server-side mutations

### DIFF
--- a/.changeset/cyan-fishes-shave.md
+++ b/.changeset/cyan-fishes-shave.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": minor
+---
+
+Skip persisted queries for server-side mutations

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -128,6 +128,7 @@ describe("gqlServerFetch", () => {
 					"Content-Type": "application/json",
 				},
 				next: { revalidate: 900 },
+				signal: expect.any(AbortSignal),
 			}
 		);
 	});

--- a/src/server.ts
+++ b/src/server.ts
@@ -77,9 +77,8 @@ export const initServerFetcher =
 			});
 		}
 
-
 		// Skip persisted queries if operation is a mutation
-		const queryType = getQueryType(query)
+		const queryType = getQueryType(query);
 		if (queryType === "mutation") {
 			return tracer.startActiveSpan(operationName, async (span) => {
 				try {
@@ -88,7 +87,7 @@ export const initServerFetcher =
 						JSON.stringify({ operationName, query, variables }),
 						{ cache, next }
 					);
-	
+
 					span.end();
 					return response as GqlResponse<TResponse>;
 				} catch (err: any) {
@@ -98,7 +97,7 @@ export const initServerFetcher =
 					});
 					throw err;
 				}
-			})
+			});
 		}
 
 		/**

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -6,10 +6,7 @@ export class TypedDocumentString<TResult, TVariables>
 {
 	__apiType?: DocumentTypeDecoration<TResult, TVariables>["__apiType"];
 
-	constructor(
-		private value: string,
-		public __meta__?: Record<string, any>,
-	) {
+	constructor(private value: string, public __meta__?: Record<string, any>) {
 		super(value);
 	}
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,20 +2,20 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
-  test: {
-    coverage: {
-      provider: "v8",
-      all: true,
-      include: ["src/**/*.ts"],
-      reportsDirectory: "./test-reports/",
-    },
+	test: {
+		coverage: {
+			provider: "v8",
+			all: true,
+			include: ["src/**/*.ts"],
+			reportsDirectory: "./test-reports/",
+		},
 		setupFiles: [path.join(__dirname, "vitest.setup.ts")],
-    passWithNoTests: true,
-  },
+		passWithNoTests: true,
+	},
 
-  resolve: {
-    alias: {
-      "~src": path.join(__dirname, "src"),
-    },
-  },
+	resolve: {
+		alias: {
+			"~src": path.join(__dirname, "src"),
+		},
+	},
 });


### PR DESCRIPTION
On TG we have a use-case which requires us to fire a server-side mutation on page load to replicate a cart from commercetools when coming back from the payment provider. 

Through this we found an issue with the library that tries to check for a persisted query for the mutation which our gateway rejects.