### PR TITLE
fix: remove json parse from ast node print

### DIFF
--- a/.changeset/friendly-tables-give.md
+++ b/.changeset/friendly-tables-give.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": patch
+---
+
+remove json parse from ast node

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -161,6 +161,7 @@ describe("gqlClientFetch", () => {
 	});
 
 	it("should use the provided timeout duration", async () => {
+		vi.useFakeTimers();
 		const fetcher = initClientFetcher("https://localhost/graphql", {
 			defaultTimeout: 1,
 		});
@@ -170,6 +171,8 @@ describe("gqlClientFetch", () => {
 		await fetcher(query, {
 			myVar: "baz",
 		});
+
+		vi.runAllTimers();
 
 		expect(timeoutSpy).toHaveBeenCalledWith(1);
 
@@ -201,16 +204,19 @@ describe("gqlClientFetch", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-
 	it("should allow passing extra HTTP headers", async () => {
 		const mockedFetch = fetchMock.mockResponse(responseString);
-		const gqlResponse = await fetcher(query, {
-			myVar: "baz",
-		}, {
-			headers: {
-				"X-extra-header": "foo",
+		const gqlResponse = await fetcher(
+			query,
+			{
+				myVar: "baz",
+			},
+			{
+				headers: {
+					"X-extra-header": "foo",
+				},
 			}
-		});
+		);
 
 		expect(gqlResponse).toEqual(response);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,9 +71,7 @@ export const initClientFetcher =
 			options.signal = AbortSignal.timeout(defaultTimeout);
 		}
 
-		const query = isNode(astNode)
-			? JSON.parse(print(astNode))
-			: astNode.toString();
+		const query = isNode(astNode) ? print(astNode) : astNode.toString();
 
 		const operationName = extractOperationName(query);
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -233,6 +233,7 @@ describe("gqlServerFetch", () => {
 	});
 
 	it("should use the provided timeout duration", async () => {
+		vi.useFakeTimers();
 		const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
 		const gqlServerFetch = initServerFetcher("https://localhost/graphql", {
 			defaultTimeout: 1,
@@ -240,6 +241,8 @@ describe("gqlServerFetch", () => {
 		fetchMock.mockResponse(successResponse);
 
 		await gqlServerFetch(query, { myVar: "baz" }, {});
+
+		vi.runAllTimers();
 
 		expect(timeoutSpy).toHaveBeenCalledWith(1);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import {
 	getQueryType,
 	pruneObject,
 } from "./helpers";
-import { print, ASTNode } from "graphql";
+import { print } from "graphql";
 import { isNode } from "graphql/language/ast";
 
 type Options = {
@@ -51,9 +51,7 @@ export const initServerFetcher =
 		{ cache, next = {} }: CacheOptions,
 		signal: AbortSignal = AbortSignal.timeout(defaultTimeout)
 	): Promise<GqlResponse<TResponse>> => {
-		const query = isNode(astNode)
-			? JSON.parse(print(astNode))
-			: astNode.toString();
+		const query = isNode(astNode) ? print(astNode) : astNode.toString();
 
 		const operationName = extractOperationName(query) || "(GraphQL)";
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -12,5 +12,5 @@ export class TypedDocumentString<TResult, TVariables>
 
 	// Choosing a leaf type will trigger the print visitor to output the value directly
 	// instead of trying to visit the children
-	kind = "StringValue";
+	kind = "IntValue";
 }


### PR DESCRIPTION
The previous fix was not correct due to a misleading test causing extra quotes.

We now don't json parse the print result anymore.