### PR TITLE
feat: allow passing headers in server fetcher

### DIFF
--- a/.changeset/gorgeous-cherries-kiss.md
+++ b/.changeset/gorgeous-cherries-kiss.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": minor
+---
+
+Allow passing headers in server fetcher, mirroring functionality of client fetcher

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,7 +11,9 @@ export const defaultHeaders: Record<string, string> = {
 
 // mergeHeaders returns a new Headers object which is a combination of the
 // passed headers and default headers if they are not set
-export const mergeHeaders = (headers: Headers | Record<string, string> | undefined): Headers => {
+export const mergeHeaders = (
+	headers: Headers | Record<string, string> | undefined
+): Headers => {
 	if (!headers) {
 		return new Headers(defaultHeaders);
 	}


### PR DESCRIPTION
This mirrors the API for the client fetcher where we already supported
this
