### PR TITLE
feat: override credentials option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .DS_Store
+test-reports

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,3 +1,4 @@
+import { createSha256 } from "helpers";
 import {
 	afterAll,
 	beforeAll,
@@ -10,7 +11,6 @@ import {
 import createFetchMock from "vitest-fetch-mock";
 import { initClientFetcher } from "./client";
 import { TypedDocumentString } from "./testing";
-import { createSha256 } from "helpers";
 
 const query = new TypedDocumentString(/* GraphQL */ `
 	query myQuery {
@@ -98,6 +98,7 @@ describe("gqlClientFetch", () => {
 			},
 		);
 	});
+
 	it("should perform a mutation", async () => {
 		const mockedFetch = fetchMock.mockResponse(responseString);
 		const gqlResponse = await fetcher(mutation, {
@@ -194,6 +195,64 @@ describe("gqlClientFetch", () => {
 
 		// It should not try to POST the query if the persisted query cannot be parsed
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("should use 'omit' credentials when provided", async () => {
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			defaultCredentials: "omit",
+		});
+		fetchMock.mockResponse(responseString);
+
+		const gqlResponse = await fetcher(query, {
+			myVar: "baz",
+		});
+
+		expect(gqlResponse).toEqual(response);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				credentials: "omit",
+			}),
+		);
+	});
+
+	it("should use 'same-origin' credentials when provided", async () => {
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			defaultCredentials: "same-origin",
+		});
+		fetchMock.mockResponse(responseString);
+
+		const gqlResponse = await fetcher(query, {
+			myVar: "baz",
+		});
+
+		expect(gqlResponse).toEqual(response);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				credentials: "same-origin",
+			}),
+		);
+	});
+
+	it("should use 'include' credentials when provided", async () => {
+		const fetcher = initClientFetcher("https://localhost/graphql");
+		fetchMock.mockResponse(responseString);
+
+		const gqlResponse = await fetcher(query, {
+			myVar: "baz",
+		});
+
+		expect(gqlResponse).toEqual(response);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				credentials: "include",
+			}),
+		);
 	});
 
 	it("should use the provided signal", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -46,6 +46,11 @@ type Options = {
 	includeQuery?: boolean;
 
 	/**
+	 * Default credentials to be sent with each request
+	 */
+	defaultCredentials?: RequestCredentials;
+
+	/**
 	 * Function to customize creating the documentId from a query
 	 *
 	 * @param query
@@ -75,6 +80,7 @@ export const initClientFetcher =
 			defaultTimeout = 30000,
 			defaultHeaders = {},
 			includeQuery = false,
+			defaultCredentials = "include",
 			createDocumentId = getDocumentId,
 		}: Options = {},
 	): ClientFetcher =>
@@ -119,7 +125,7 @@ export const initClientFetcher =
 				fetch(url.toString(), {
 					headers: headers,
 					method: "GET",
-					credentials: "include",
+					credentials: defaultCredentials,
 					signal: options.signal,
 				}),
 			);
@@ -140,7 +146,7 @@ export const initClientFetcher =
 					headers: headers,
 					method: "POST",
 					body: createRequestBody(request),
-					credentials: "include",
+					credentials: defaultCredentials,
 					signal: options.signal,
 				}),
 			);


### PR DESCRIPTION
## Context

In some projects, I need the ability to manually override the credentials option in the Fetch API.

## Changes

- Added a `defaultCredentials` option to allow manual overriding of the credentials setting.