### PR TITLE
fix: query serialization producing `[object Object]`

### DIFF
--- a/.changeset/fix-query-serialization.md
+++ b/.changeset/fix-query-serialization.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": patch
+---
+
+Fix query serialization producing `[object Object]` instead of the actual query string

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,5 @@
 import type { DocumentTypeDecoration } from "@graphql-typed-document-node/core";
 import { type GraphQLError, print } from "graphql";
-import { isNode } from "graphql/language/ast.js";
 import {
 	createRequest,
 	createRequestBody,
@@ -130,9 +129,9 @@ export const initClientFetcher =
 		}
 
 		const query =
-			isNode(astNode) && astNode.kind === "Document"
-				? print(astNode)
-				: astNode.toString();
+			typeof astNode === "string" || astNode instanceof String
+				? astNode.toString()
+				: print(astNode as Parameters<typeof print>[0]);
 		const documentId = createDocumentId(astNode);
 		const request = await createRequest(
 			query,

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,6 @@ import {
 	hasPersistedQueryError,
 } from "./helpers";
 import { print, type GraphQLError } from "graphql";
-import { isNode } from "graphql/language/ast.js";
 import {
 	createRequest,
 	createRequestBody,
@@ -118,9 +117,9 @@ export const initServerFetcher =
 		options: RequestOptions = {},
 	): Promise<GqlResponse<TResponse>> => {
 		const query =
-			isNode(astNode) && astNode.kind === "Document"
-				? print(astNode)
-				: astNode.toString();
+			typeof astNode === "string" || astNode instanceof String
+				? astNode.toString()
+				: print(astNode as Parameters<typeof print>[0]);
 
 		const documentId = createDocumentId(astNode);
 		const request = await createRequest(


### PR DESCRIPTION
This pull request fixes an issue where GraphQL query serialization could result in `[object Object]` instead of the actual query string. The changes ensure that queries are properly converted to strings before being sent, improving reliability for both client and server fetchers.

**Bug Fix: Query Serialization**

* Updated both `initClientFetcher` in `src/client.ts` and `initServerFetcher` in `src/server.ts` to correctly serialize the GraphQL query, ensuring that if the AST node is a string it is used as-is, otherwise it is printed using the `print` function. This prevents `[object Object]` from being sent as the query. [[1]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L133-R134) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L121-R122)
* Removed the unused import of `isNode` from `graphql/language/ast.js` in both `src/client.ts` and `src/server.ts` as it is no longer needed for type checking. [[1]](diffhunk://#diff-25d66d74617fe2e23d7946bd6e3ba95640ab1b9bc8947445d604fc271c7c1f12L3) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L14)

**Changelog**

* Added a changeset entry describing the fix for query serialization in `@labdigital/graphql-fetcher`.