### PR TITLE
fix memory leak because of unclosed otel spans

### DIFF
--- a/.changeset/upset-animals-begin.md
+++ b/.changeset/upset-animals-begin.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": patch
+---
+
+Fix memory leak because of unclosed spans

--- a/src/server.ts
+++ b/src/server.ts
@@ -154,7 +154,6 @@ export const initServerFetcher =
 						requestOptions,
 					);
 
-					span.end();
 					return response as GqlResponse<TResponse>;
 				} catch (err: any) {
 					span.setStatus({
@@ -162,6 +161,8 @@ export const initServerFetcher =
 						message: err?.message ?? String(err),
 					});
 					throw err;
+				} finally {
+					span.end();
 				}
 			});
 		}
@@ -178,7 +179,6 @@ export const initServerFetcher =
 						requestOptions,
 					);
 
-					span.end();
 					return response as GqlResponse<TResponse>;
 				} catch (err: unknown) {
 					span.setStatus({
@@ -186,6 +186,8 @@ export const initServerFetcher =
 						message: err instanceof Error ? err.message : String(err),
 					});
 					throw err;
+				} finally {
+					span.end();
 				}
 			});
 		}
@@ -213,7 +215,6 @@ export const initServerFetcher =
 					);
 				}
 
-				span.end();
 				return response as GqlResponse<TResponse>;
 			} catch (err: any) {
 				span.setStatus({
@@ -221,6 +222,8 @@ export const initServerFetcher =
 					message: err?.message ?? String(err),
 				});
 				throw err;
+			} finally {
+				span.end();
 			}
 		});
 	};


### PR DESCRIPTION
Issue description:

server.ts creates an OpenTelemetry span for every server-side GraphQL request. 
On success the span is ended. On error it is not. 
The catch block sets an error status but never calls span.end(), and there is no finally block.

```ts
return tracer.startActiveSpan(request.operationName, async (span) => {
  try {
    const response = await gqlPersistedQuery(...);
    span.end();          // called on success
    return response;
  } catch (err) {
    span.setStatus({ code: SpanStatusCode.ERROR, ... });
    throw err;          // span.end() is never called!  }
});
```

**Why this leaks memory**
An unfinished span stays alive in the OpenTelemetry SDK indefinitely.
Every failed GraphQL fetch (timeout, network error, 5xx) permanently leaks an entire request’s worth of objects.