### PR TITLE
feat: add onGraphQLErrors hook for consumer-side error handling

### DIFF
--- a/.changeset/graphql-errors-hook.md
+++ b/.changeset/graphql-errors-hook.md
@@ -1,0 +1,13 @@
+---
+"@labdigital/graphql-fetcher": minor
+---
+
+Add `onGraphQLErrors` and `onRequestError` hooks so consumers can observe and act on failures the fetcher previously swallowed — both on the client and server fetchers. The library takes no action of its own; each hook decides whether to log, ignore, or `throw` to escalate, and both are awaited so a throwing callback rejects the fetch call. They are orthogonal to `retry` (which controls whether to try again) and fire terminally, after retries are exhausted.
+
+- **`onGraphQLErrors`** — fires when a `2xx` response carries GraphQL errors (e.g. a partial-data response where one field errored), which were previously returned in `errors` and easily ignored.
+  `(errors: GraphQLError[], context: { operationName, documentId?, variables, response, httpResponse }) => void | Promise<void>`. The context includes the parsed `response` (so the callback can inspect partial `data` alongside the errors) and the raw `httpResponse` (status/headers, e.g. a gateway request id). The internal `PersistedQueryNotFound` signal is filtered out of `errors`.
+- **`onRequestError`** — fires when a request fails with a thrown error: a non-2xx response (a `GraphQLFetcherError` carrying `.status`/`.body`/`.response`), or a network/timeout error (which previously logged nothing at all).
+  `(error: unknown, context: { operationName, documentId?, variables }) => void | Promise<void>`. Not triggered when `onGraphQLErrors` itself throws (that is a GraphQL-error escalation, not a request failure).
+- Exports `OnGraphQLErrors`, `OnRequestError`, `GraphQLErrorContext`, and `RequestContext` types.
+- The `GraphQLError` type now includes optional `path` and `locations`.
+- The `logger` is now transport-only: it no longer logs GraphQL errors on a 2xx (that is `onGraphQLErrors`' job). It still logs failed requests, persisted-query fallbacks, and retries.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Only used for fetching from GraphQL endpoints.
 - Next data cache support
 - Retry hook for refresh-and-retry flows (e.g. on a 401)
 - Typed `GraphQLFetcherError` carrying the HTTP status and response body
+- `onGraphQLErrors` / `onRequestError` hooks to observe or escalate failures
 - Optional structured logger to surface otherwise-swallowed failures
 
 
@@ -104,13 +105,62 @@ try {
 }
 ```
 
+## Error hooks
+
+Two optional hooks let you observe or escalate failures the fetcher would
+otherwise swallow. They are available on both the client and server fetchers.
+The library takes no action of its own — each hook decides whether to log,
+ignore, or `throw` to escalate. Both are **awaited**, so throwing (or returning
+a rejecting promise) rejects the fetch call. They are **orthogonal to `retry`**
+(which controls whether to try again) and fire **terminally**, after any retries
+are exhausted.
+
+### `onGraphQLErrors` — GraphQL errors on a 2xx
+
+Fires when a `2xx` response carries GraphQL errors (e.g. a partial-data response
+where one field errored). These are returned in `errors` and easily ignored,
+which leads to silent failures downstream. The callback receives the errors and
+a context with the request, the parsed `response` (inspect partial `data`), and
+the raw `httpResponse` (status / headers, e.g. a gateway request id). The
+internal `PersistedQueryNotFound` fallback signal is filtered out.
+
+```ts
+const fetcher = initServerFetcher("https://localhost/graphql", {
+	onGraphQLErrors: (errors, { operationName, variables, response }) => {
+		// Log, ignore legitimate partial data, or throw to escalate.
+		logger.warn({ operationName, variables, errors }, "GraphQL errors");
+	},
+});
+```
+
+### `onRequestError` — the request threw
+
+Fires when a request fails with a thrown error: a non-2xx response (a
+`GraphQLFetcherError` carrying `.status` / `.body` / `.response`), or a
+network / timeout error (which otherwise logs nothing at all). It is **not**
+triggered when `onGraphQLErrors` itself throws — that is a GraphQL-error
+escalation, not a request failure.
+
+```ts
+import { GraphQLFetcherError } from "@labdigital/graphql-fetcher";
+
+const fetcher = initServerFetcher("https://localhost/graphql", {
+	onRequestError: (error, { operationName }) => {
+		const status =
+			error instanceof GraphQLFetcherError ? error.status : undefined;
+		logger.error({ operationName, status, err: error }, "Request failed");
+	},
+});
+```
+
 ## Logging
 
 Both `initClientFetcher` and `initServerFetcher` accept an optional `logger`.
-When set, the fetcher surfaces conditions it would otherwise swallow: failed
-requests, persisted-query fallbacks, GraphQL errors returned on a 2xx response,
-and retries. All methods are optional, so you can pass `console` or a partial
-object.
+It surfaces **transport-level** conditions that would otherwise be swallowed:
+failed requests, persisted-query fallbacks, and retries. (GraphQL errors on a
+2xx are handled by `onGraphQLErrors` instead, since whether they are fatal is a
+consumer concern.) All methods are optional, so you can pass `console` or a
+partial object.
 
 ```ts
 const fetcher = initClientFetcher("https://localhost/graphql", {
@@ -123,16 +173,6 @@ const fetcher = initClientFetcher("https://localhost/graphql", {
 ```
 
 ## Notes
-
-### Node 18.x requires webcrypto on globalThis
-
-From node 20.x onwards the WebCrypto API is available on globalThis, versions before 20.x will need a small polyfill:
-
-```
-	if (typeof window === "undefined" && !globalThis.crypto) {
-		globalThis.crypto = require("node:crypto").webcrypto;
-	}
-```
 
 ### Old browsers might need a AbortSignal.timeout() polyfill
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -488,7 +488,7 @@ describe("logger", () => {
 		);
 	});
 
-	it("warns when a 2xx response carries GraphQL errors", async () => {
+	it("does not use the logger for GraphQL errors on a 2xx (that is onGraphQLErrors' job)", async () => {
 		server.use(
 			http.post("https://localhost/graphql", () =>
 				HttpResponse.json({
@@ -498,14 +498,12 @@ describe("logger", () => {
 			),
 		);
 
-		const logger = { warn: vi.fn() };
+		const logger = { warn: vi.fn(), error: vi.fn() };
 		const fetcher = initClientFetcher("https://localhost/graphql", { logger });
 
 		await fetcher(query, { myVar: "baz" });
-		expect(logger.warn).toHaveBeenCalledWith(
-			"GraphQL response contained errors",
-			expect.objectContaining({ operationName: "myQuery" }),
-		);
+		expect(logger.warn).not.toHaveBeenCalled();
+		expect(logger.error).not.toHaveBeenCalled();
 	});
 
 	it("does not warn for the PersistedQueryNotFound fallback signal", async () => {
@@ -530,6 +528,184 @@ describe("logger", () => {
 			"Persisted query not found, falling back to POST",
 			expect.objectContaining({ operationName: "myQuery" }),
 		);
+	});
+});
+
+describe("onGraphQLErrors", () => {
+	const errorResponseBody = JSON.stringify({
+		data: { catalogPage: { name: "Tennis" } },
+		errors: [
+			{
+				message: "Category not found",
+				path: ["catalogPage", "productListingConfig"],
+				extensions: { code: "NOT_FOUND" },
+			},
+		],
+	});
+
+	it("calls the hook with errors and request context on a 2xx-with-errors", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.text(errorResponseBody, {
+					headers: { "x-request-id": "req-123" },
+				}),
+			),
+		);
+
+		const onGraphQLErrors = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onGraphQLErrors,
+		});
+
+		await fetcher(query, { myVar: "baz" });
+
+		expect(onGraphQLErrors).toHaveBeenCalledTimes(1);
+		const [errors, context] = onGraphQLErrors.mock.calls[0];
+		expect(errors[0].message).toBe("Category not found");
+		expect(context).toMatchObject({
+			operationName: "myQuery",
+			variables: { myVar: "baz" },
+		});
+		// The full response is available so the callback can inspect partial data.
+		expect(context.response.data).toEqual({ catalogPage: { name: "Tennis" } });
+		expect(context.response.errors).toHaveLength(1);
+		// The raw HTTP response exposes status and headers.
+		expect(context.httpResponse.status).toBe(200);
+		expect(context.httpResponse.headers.get("x-request-id")).toBe("req-123");
+	});
+
+	it("is not called for a clean response", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.text(successResponse),
+			),
+		);
+
+		const onGraphQLErrors = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onGraphQLErrors,
+		});
+
+		await fetcher(query, { myVar: "baz" });
+		expect(onGraphQLErrors).not.toHaveBeenCalled();
+	});
+
+	it("does not fire for the PersistedQueryNotFound fallback signal", async () => {
+		server.use(
+			http.get("https://localhost/graphql", () =>
+				HttpResponse.text(errorResponse),
+			),
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.text(successResponse),
+			),
+		);
+
+		const onGraphQLErrors = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			persistedQueries: true,
+			onGraphQLErrors,
+		});
+
+		await fetcher(query, { myVar: "baz" });
+		expect(onGraphQLErrors).not.toHaveBeenCalled();
+	});
+
+	it("rejects the fetch call when the hook throws (escalate path)", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.text(errorResponseBody),
+			),
+		);
+
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onGraphQLErrors: (errors) => {
+				throw new Error(errors[0].message);
+			},
+		});
+
+		await expect(fetcher(query, { myVar: "baz" })).rejects.toThrow(
+			"Category not found",
+		);
+	});
+});
+
+describe("onRequestError", () => {
+	it("is called with the thrown error on a non-2xx", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.json({}, { status: 500 }),
+			),
+		);
+
+		const onRequestError = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onRequestError,
+		});
+
+		await expect(fetcher(query, { myVar: "baz" })).rejects.toBeInstanceOf(
+			GraphQLFetcherError,
+		);
+		expect(onRequestError).toHaveBeenCalledTimes(1);
+		const [error, context] = onRequestError.mock.calls[0];
+		expect(error).toBeInstanceOf(GraphQLFetcherError);
+		expect(error.status).toBe(500);
+		expect(context).toMatchObject({ operationName: "myQuery" });
+	});
+
+	it("is not called for a successful response", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.text(successResponse),
+			),
+		);
+
+		const onRequestError = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onRequestError,
+		});
+
+		await fetcher(query, { myVar: "baz" });
+		expect(onRequestError).not.toHaveBeenCalled();
+	});
+
+	it("fires once, after retries are exhausted", async () => {
+		const spy = spyOnFetch();
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.json({}, { status: 401 }),
+			),
+		);
+
+		const onRequestError = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			retry: { max: 2, shouldRetry: () => true },
+			onRequestError,
+		});
+
+		await expect(fetcher(query, { myVar: "baz" })).rejects.toBeInstanceOf(
+			GraphQLFetcherError,
+		);
+		expect(spy).toHaveBeenCalledTimes(3); // initial + 2 retries
+		expect(onRequestError).toHaveBeenCalledTimes(1); // terminal only
+	});
+
+	it("is not triggered when onGraphQLErrors throws (escalation, not a request error)", async () => {
+		server.use(
+			http.post("https://localhost/graphql", () =>
+				HttpResponse.json({ data: null, errors: [{ message: "boom" }] }),
+			),
+		);
+
+		const onRequestError = vi.fn();
+		const fetcher = initClientFetcher("https://localhost/graphql", {
+			onGraphQLErrors: () => {
+				throw new Error("escalated");
+			},
+			onRequestError,
+		});
+
+		await expect(fetcher(query, { myVar: "baz" })).rejects.toThrow("escalated");
+		expect(onRequestError).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,10 @@ import {
 	hasPersistedQueryError,
 	type Logger,
 	mergeHeaders,
+	type OnGraphQLErrors,
+	type OnRequestError,
+	reportGraphQLErrors,
+	reportRequestError,
 } from "./helpers";
 
 /**
@@ -100,11 +104,25 @@ type Options = {
 	retry?: RetryOptions;
 
 	/**
-	 * Optional logger. When set, the fetcher surfaces conditions it would
-	 * otherwise swallow: failed requests, persisted-query fallbacks, GraphQL
-	 * errors returned on a 2xx response, and retries.
+	 * Optional logger. When set, the fetcher surfaces transport-level conditions
+	 * it would otherwise swallow: failed requests, persisted-query fallbacks, and
+	 * retries.
 	 */
 	logger?: Logger;
+
+	/**
+	 * Called when a response carries GraphQL errors (on a 2xx). The library takes
+	 * no action of its own; the callback decides whether to log, ignore, or throw
+	 * to escalate. It is awaited, so throwing rejects the fetch call.
+	 */
+	onGraphQLErrors?: OnGraphQLErrors;
+
+	/**
+	 * Called when a request fails with a thrown error (non-2xx, network, or
+	 * timeout), terminally after any retries. Observation/escalation only and
+	 * orthogonal to `retry`; `throw` to replace the error.
+	 */
+	onRequestError?: OnRequestError;
 };
 
 type RequestOptions = {
@@ -162,6 +180,8 @@ export const initClientFetcher =
 			createDocumentId = getDocumentId,
 			retry,
 			logger,
+			onGraphQLErrors,
+			onRequestError,
 		}: Options = {},
 	): ClientFetcher =>
 	/**
@@ -200,6 +220,10 @@ export const initClientFetcher =
 
 		apq = apq || persistedQueries;
 
+		// Holds the raw HTTP response of the final attempt so it can be handed to
+		// `onGraphQLErrors`. Set on every successful parse.
+		let httpResponse: Response | undefined;
+
 		// A single end-to-end attempt: the (optional) persisted GET plus the POST
 		// fallback. The retry wrapper re-runs this whole function, so cookies
 		// refreshed in `onRetry` are picked up on the next attempt.
@@ -209,7 +233,7 @@ export const initClientFetcher =
 			// For queries we can use GET requests if persisted queries are enabled
 			if (queryType === "query" && (apq || isPersistedQuery(request))) {
 				const url = createRequestURL(endpoint, request);
-				response = await parseResponse<GqlResponse<TResponse>>(
+				const parsed = await parseResponse<GqlResponse<TResponse>>(
 					() =>
 						fetch(url.toString(), {
 							headers: headers,
@@ -220,6 +244,8 @@ export const initClientFetcher =
 					request.operationName,
 					logger,
 				);
+				response = parsed.body;
+				httpResponse = parsed.response;
 			}
 
 			// For failed APQ calls or mutations we need to fall back to POST requests
@@ -238,7 +264,7 @@ export const initClientFetcher =
 
 				// Persisted query not used or found, fall back to POST request and
 				// include extension to cache the query on the server
-				response = await parseResponse<GqlResponse<TResponse>>(
+				const parsed = await parseResponse<GqlResponse<TResponse>>(
 					() =>
 						fetch(url.toString(), {
 							headers: headers,
@@ -250,26 +276,42 @@ export const initClientFetcher =
 					request.operationName,
 					logger,
 				);
-			}
-
-			// Surface GraphQL errors that come back on a 2xx -- these are returned
-			// in the response and routinely ignored by callers. The expected
-			// PersistedQueryNotFound signal is excluded as it drives the fallback
-			// above rather than being a real failure.
-			const errors = response.errors?.filter(
-				(error) => error.message !== "PersistedQueryNotFound",
-			);
-			if (errors?.length) {
-				logger?.warn?.("GraphQL response contained errors", {
-					operationName: request.operationName,
-					errors,
-				});
+				response = parsed.body;
+				httpResponse = parsed.response;
 			}
 
 			return response;
 		};
 
-		return runWithRetry(execute, retry, logger);
+		const requestContext = {
+			operationName: request.operationName,
+			documentId: request.documentId,
+			variables: request.variables,
+		};
+
+		// A thrown error (non-2xx, network, timeout) is terminal after retries.
+		// Hand it to onRequestError before it propagates. onGraphQLErrors lives
+		// outside this try, so its escalation throws are not re-reported here.
+		let result: GqlResponse<TResponse>;
+		try {
+			result = await runWithRetry(execute, retry, logger);
+		} catch (error) {
+			await reportRequestError(error, requestContext, onRequestError);
+			throw error;
+		}
+
+		// GraphQL errors on a 2xx are handed to the consumer's callback (which may
+		// log, ignore, or throw). Done after the retry loop so a throwing callback
+		// rejects cleanly rather than being treated as a retryable failure. A
+		// resolved result always means a successful parse, so httpResponse is set.
+		await reportGraphQLErrors(
+			result,
+			requestContext,
+			httpResponse as Response,
+			onGraphQLErrors,
+		);
+
+		return result;
 	};
 
 /**
@@ -323,8 +365,9 @@ const runWithRetry = async <T>(
 };
 
 /**
- * Checks if fetch succeeded and parses the response body
- * @returns GraphQL response body
+ * Checks if fetch succeeded and parses the response body, returning both the
+ * parsed body and the raw `Response` (the latter so callers can read headers /
+ * status for `onGraphQLErrors`).
  * @param fetchFn
  * @param operationName operation name, attached to the thrown error for context
  */
@@ -332,7 +375,7 @@ const parseResponse = async <T>(
 	fetchFn: () => Promise<Response>,
 	operationName?: string,
 	logger?: Logger,
-): Promise<T> => {
+): Promise<{ body: T; response: Response }> => {
 	const response = await fetchFn();
 	if (!response.ok) {
 		const error = await GraphQLFetcherError.fromResponse(
@@ -348,5 +391,5 @@ const parseResponse = async <T>(
 		throw error;
 	}
 
-	return (await response.json()) as T;
+	return { body: (await response.json()) as T, response };
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,6 +37,8 @@ export const getDocumentId = <TResult, TVariables>(
 
 export type GraphQLError = {
 	message: string;
+	path?: (string | number)[];
+	locations?: { line: number; column: number }[];
 	extensions: {
 		code: string;
 		serviceName: string;
@@ -52,14 +54,107 @@ export type GqlResponse<TResponse> = {
 
 /**
  * Optional structured logger. All methods are optional, so a partial object
- * (or `console`) can be passed. The fetcher uses this to surface conditions it
- * would otherwise swallow -- failed requests, persisted-query fallbacks,
- * GraphQL errors returned on a 2xx, and retries.
+ * (or `console`) can be passed. The fetcher uses this to surface transport-level
+ * conditions it would otherwise swallow -- failed requests, persisted-query
+ * fallbacks, and retries. GraphQL errors returned on a 2xx are handled by
+ * `onGraphQLErrors` instead, since whether they are fatal is a consumer concern.
  */
 export type Logger = {
 	debug?: (message: string, meta?: Record<string, unknown>) => void;
 	warn?: (message: string, meta?: Record<string, unknown>) => void;
 	error?: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+/**
+ * Identifies the request that produced an error. Shared by the terminal error
+ * hooks (`onRequestError`, `onGraphQLErrors`).
+ */
+export type RequestContext = {
+	operationName: string;
+	documentId?: string;
+	variables: unknown;
+};
+
+/**
+ * Context passed to `onGraphQLErrors`: the request that produced the errors plus
+ * the full response, so the callback can inspect partial `data` alongside the
+ * errors (e.g. to tell a tolerable partial-data response from a total failure).
+ */
+export type GraphQLErrorContext = RequestContext & {
+	/** Parsed GraphQL response -- inspect partial `data` alongside the errors. */
+	response: GqlResponse<unknown>;
+	/**
+	 * Raw HTTP response, for status and headers (e.g. a gateway request id). Its
+	 * body stream is already consumed; read `response` for the parsed payload.
+	 */
+	httpResponse: Response;
+};
+
+/**
+ * Called when a response carries GraphQL errors (on any HTTP status), with the
+ * internal `PersistedQueryNotFound` fallback signal filtered out. The library
+ * takes no action of its own -- the consumer decides whether to log, ignore
+ * legitimate partial-data errors, or `throw` to escalate. The callback is
+ * awaited, so throwing (or returning a rejecting promise) rejects the fetch call.
+ */
+export type OnGraphQLErrors = (
+	errors: GraphQLError[],
+	context: GraphQLErrorContext,
+) => void | Promise<void>;
+
+/**
+ * Called when a request fails with a thrown error -- a non-2xx response (a
+ * `GraphQLFetcherError` carrying `.status`/`.body`/`.response`), or a network /
+ * timeout error. Fires once, terminally, after any retries are exhausted and
+ * before the error propagates. This is observation/escalation only -- it is
+ * orthogonal to `retry`, which controls whether to try again. Logging is the
+ * typical use; `throw` to replace the error. Not called when `onGraphQLErrors`
+ * itself throws (that is a GraphQL-error escalation, not a request failure).
+ */
+export type OnRequestError = (
+	error: unknown,
+	context: RequestContext,
+) => void | Promise<void>;
+
+/**
+ * Filters out the internal `PersistedQueryNotFound` signal and, if any GraphQL
+ * errors remain, hands them -- with the full response -- to `onGraphQLErrors`.
+ * Awaited so a throwing callback propagates.
+ */
+export const reportGraphQLErrors = async (
+	result: GqlResponse<unknown>,
+	request: RequestContext,
+	httpResponse: Response,
+	onGraphQLErrors?: OnGraphQLErrors,
+): Promise<void> => {
+	if (!onGraphQLErrors) {
+		return;
+	}
+
+	const errors = result.errors?.filter(
+		(error) => error.message !== "PersistedQueryNotFound",
+	);
+	if (errors?.length) {
+		await onGraphQLErrors(errors, {
+			...request,
+			response: result,
+			httpResponse,
+		});
+	}
+};
+
+/**
+ * Hands a thrown request error to `onRequestError`, if set. Awaited so a
+ * throwing callback (which replaces the error) propagates.
+ */
+export const reportRequestError = async (
+	error: unknown,
+	request: RequestContext,
+	onRequestError?: OnRequestError,
+): Promise<void> => {
+	if (onRequestError) {
+		await onRequestError(error, request);
+	}
 };
 
 export interface NextFetchRequestConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,15 @@ export type {
 } from "./client";
 export { initClientFetcher, initStrictClientFetcher } from "./client";
 export { GraphQLFetcherError } from "./errors";
-export type { GqlResponse, GraphQLError, Logger } from "./helpers";
+export type {
+	GqlResponse,
+	GraphQLError,
+	GraphQLErrorContext,
+	Logger,
+	OnGraphQLErrors,
+	OnRequestError,
+	RequestContext,
+} from "./helpers";
 export { ClientGqlFetcherProvider, useClientGqlFetcher } from "./provider";
 export {
 	StrictClientGqlFetcherProvider,

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,10 @@ import {
 	type Logger,
 	mergeHeaders,
 	type NextFetchRequestConfig,
+	type OnGraphQLErrors,
+	type OnRequestError,
+	reportGraphQLErrors,
+	reportRequestError,
 } from "./helpers";
 import {
 	createRequest,
@@ -21,7 +25,13 @@ import {
 } from "./request";
 
 export { GraphQLFetcherError } from "./errors";
-export type { Logger } from "./helpers";
+export type {
+	GraphQLErrorContext,
+	Logger,
+	OnGraphQLErrors,
+	OnRequestError,
+	RequestContext,
+} from "./helpers";
 
 type RequestOptions = {
 	/**
@@ -70,6 +80,19 @@ type Options = {
 	 * persisted-query fallbacks that would otherwise be swallowed.
 	 */
 	logger?: Logger;
+
+	/**
+	 * Called when a response carries GraphQL errors (on a 2xx). The library takes
+	 * no action of its own; the callback decides whether to log, ignore, or throw
+	 * to escalate. It is awaited, so throwing rejects the fetch call.
+	 */
+	onGraphQLErrors?: OnGraphQLErrors;
+
+	/**
+	 * Called when a request fails with a thrown error (non-2xx, network, or
+	 * timeout). Observation/escalation only; `throw` to replace the error.
+	 */
+	onRequestError?: OnRequestError;
 };
 
 type CacheOptions = {
@@ -118,6 +141,8 @@ export const initServerFetcher =
 			includeQuery = false,
 			createDocumentId = getDocumentId,
 			logger,
+			onGraphQLErrors,
+			onRequestError,
 		}: Options = {},
 	) =>
 	async <TResponse, TVariables>(
@@ -147,6 +172,20 @@ export const initServerFetcher =
 			headers: mergeHeaders({ ...defaultHeaders, ...options.headers }),
 		};
 
+		// Runs a fetch step and routes a thrown error (non-2xx, network, timeout)
+		// to onRequestError before rethrowing. Scoped to the fetch only, so a
+		// throwing onGraphQLErrors (a GraphQL-error escalation) is not re-reported.
+		const fetchWithErrorReport = async <T>(
+			fetchStep: () => Promise<T>,
+		): Promise<T> => {
+			try {
+				return await fetchStep();
+			} catch (error) {
+				await reportRequestError(error, request, onRequestError);
+				throw error;
+			}
+		};
+
 		// When cache is disabled we always make a POST request and set the
 		// cache to no-store to prevent any caching
 		if (dangerouslyDisableCache) {
@@ -157,14 +196,23 @@ export const initServerFetcher =
 
 			return tracer.startActiveSpan(request.operationName, async (span) => {
 				try {
-					const response = await gqlPost(
-						url,
-						request,
-						{ ...next, cache: "no-store" },
-						requestOptions,
-						logger,
+					const { body: response, httpResponse } = await fetchWithErrorReport(
+						() =>
+							gqlPost(
+								url,
+								request,
+								{ ...next, cache: "no-store" },
+								requestOptions,
+								logger,
+							),
 					);
 
+					await reportGraphQLErrors(
+						response,
+						request,
+						httpResponse,
+						onGraphQLErrors,
+					);
 					return response as GqlResponse<TResponse>;
 				} catch (err: any) {
 					span.setStatus({
@@ -183,14 +231,17 @@ export const initServerFetcher =
 		if (queryType === "mutation") {
 			return tracer.startActiveSpan(request.operationName, async (span) => {
 				try {
-					const response = await gqlPost(
-						url,
-						request,
-						{ cache, next },
-						requestOptions,
-						logger,
+					const { body: response, httpResponse } = await fetchWithErrorReport(
+						() =>
+							gqlPost(url, request, { cache, next }, requestOptions, logger),
 					);
 
+					await reportGraphQLErrors(
+						response,
+						request,
+						httpResponse,
+						onGraphQLErrors,
+					);
 					return response as GqlResponse<TResponse>;
 				} catch (err: unknown) {
 					span.setStatus({
@@ -207,12 +258,14 @@ export const initServerFetcher =
 		// Otherwise, try to get the cached query
 		return tracer.startActiveSpan(request.operationName, async (span) => {
 			try {
-				let response = await gqlPersistedQuery(
-					url,
-					request,
-					{ cache, next },
-					requestOptions,
-					logger,
+				let { body: response, httpResponse } = await fetchWithErrorReport(() =>
+					gqlPersistedQuery(
+						url,
+						request,
+						{ cache, next },
+						requestOptions,
+						logger,
+					),
 				);
 
 				// If this is not a persisted query, but we tried to use automatic
@@ -223,15 +276,17 @@ export const initServerFetcher =
 					});
 					// If the cached query doesn't exist, fall back to POST request and
 					// let the server cache it.
-					response = await gqlPost(
-						url,
-						request,
-						{ cache, next },
-						requestOptions,
-						logger,
-					);
+					({ body: response, httpResponse } = await fetchWithErrorReport(() =>
+						gqlPost(url, request, { cache, next }, requestOptions, logger),
+					));
 				}
 
+				await reportGraphQLErrors(
+					response,
+					request,
+					httpResponse,
+					onGraphQLErrors,
+				);
 				return response as GqlResponse<TResponse>;
 			} catch (err: any) {
 				span.setStatus({
@@ -264,7 +319,10 @@ const gqlPost = async <TVariables>(
 		signal: options.signal,
 	});
 
-	return parseResponse(request, response, logger);
+	return {
+		body: await parseResponse(request, response, logger),
+		httpResponse: response,
+	};
 };
 
 const gqlPersistedQuery = async <TVariables>(
@@ -283,7 +341,10 @@ const gqlPersistedQuery = async <TVariables>(
 		signal: options.signal,
 	});
 
-	return parseResponse(request, response, logger);
+	return {
+		body: await parseResponse(request, response, logger),
+		httpResponse: response,
+	};
 };
 
 /**


### PR DESCRIPTION
GraphQL errors returned on a 2xx (e.g. partial-data responses) were
returned in `errors` and easily ignored, causing silent failures. The
fetcher now hands them to a consumer-provided `onGraphQLErrors` callback
with the request context and takes no action itself -- the consumer
decides to log, ignore, or throw to escalate. The callback is awaited so
a throw rejects the fetch call.

Moves GraphQL-error responsibility out of `logger` (now transport-only)
and into the consumer, on both the client and server fetchers.
