### PR TITLE
feat!: move React provider/hooks to ./react entry

### DIFF
--- a/.changeset/react-entry-split.md
+++ b/.changeset/react-entry-split.md
@@ -1,0 +1,16 @@
+---
+"@labdigital/graphql-fetcher": major
+---
+
+Move the React provider/hook exports to a dedicated `./react` entry so the package root is framework-neutral.
+
+The root entry previously re-exported the React providers, which call `createContext` at module load. Because the bundle is not code-split, importing **anything** from the root (even the plain `GraphQLFetcherError` class or a type) evaluated `createContext` — which crashes in React Server Components (`createContext is not a function`). The root entry is now React-free and safe to import in RSC / server code; the providers live in `./react` (marked `"use client"`).
+
+**Breaking change — migrate provider/hook imports:**
+
+```diff
+- import { ClientGqlFetcherProvider, useClientGqlFetcher } from "@labdigital/graphql-fetcher";
++ import { ClientGqlFetcherProvider, useClientGqlFetcher } from "@labdigital/graphql-fetcher/react";
+```
+
+This also applies to `StrictClientGqlFetcherProvider` and `useStrictClientGqlFetcher`. All other exports — `initClientFetcher`, `initStrictClientFetcher`, `GraphQLFetcherError`, and every type (`GqlResponse`, `GraphQLError`, `OnGraphQLErrors`, `OnRequestError`, `RetryOptions`, …) — remain on the package root. The `./server` entry is unchanged.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
 			"types": "./dist/server.d.ts",
 			"import": "./dist/server.js",
 			"require": "./dist/server.cjs"
+		},
+		"./react": {
+			"types": "./dist/react.d.ts",
+			"import": "./dist/react.js",
+			"require": "./dist/react.cjs"
 		}
 	},
 	"author": "Lab Digital <opensource@labdigital.nl>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,6 @@ export type {
 	OnRequestError,
 	RequestContext,
 } from "./helpers";
-export { ClientGqlFetcherProvider, useClientGqlFetcher } from "./provider";
-export {
-	StrictClientGqlFetcherProvider,
-	useStrictClientGqlFetcher,
-} from "./strict-provider";
+
+// React providers/hooks live in the `./react` entry so this root entry stays
+// framework-neutral and safe to import in React Server Components.

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,12 @@
+"use client";
+
+export type { ClientGqlFetcherProviderProps } from "./provider";
+export {
+	ClientGqlFetcherProvider,
+	useClientGqlFetcher,
+} from "./provider";
+export type { StrictClientGqlFetcherProviderProps } from "./strict-provider";
+export {
+	StrictClientGqlFetcherProvider,
+	useStrictClientGqlFetcher,
+} from "./strict-provider";

--- a/tsdown.config.js
+++ b/tsdown.config.js
@@ -21,4 +21,14 @@ export default defineConfig([
 		outDir: "dist",
 		fixedExtension: false,
 	},
+	{
+		entry: ["src/react.ts"],
+		clean: true,
+		splitting: false,
+		dts: true,
+		sourcemap: true,
+		format: ["esm", "cjs"],
+		outDir: "dist",
+		fixedExtension: false,
+	},
 ]);


### PR DESCRIPTION
The root entry re-exported the React providers, which call createContext at
module load. With no code-splitting, importing anything from the root (even
the plain GraphQLFetcherError class or a type) evaluated createContext, which
crashes in React Server Components. The root entry is now framework-neutral;
the providers live in a dedicated ./react entry marked "use client".

BREAKING CHANGE: import ClientGqlFetcherProvider / useClientGqlFetcher (and the
Strict variants) from @labdigital/graphql-fetcher/react instead of the root.
