### PR TITLE
feat: add query string to error-hook context

### DIFF
--- a/.changeset/query-in-context.md
+++ b/.changeset/query-in-context.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-fetcher": patch
+---
+
+Add the GraphQL `query` string to the error-hook context (`RequestContext`), so `onGraphQLErrors` and `onRequestError` callbacks can log the actual query for diagnostics — not just the `operationName` / `documentId`. Purely additive; existing callbacks are unaffected.

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -566,6 +566,8 @@ describe("onGraphQLErrors", () => {
 			operationName: "myQuery",
 			variables: { myVar: "baz" },
 		});
+		// The query string is available for diagnostics.
+		expect(context.query).toContain("query myQuery");
 		// The full response is available so the callback can inspect partial data.
 		expect(context.response.data).toEqual({ catalogPage: { name: "Tennis" } });
 		expect(context.response.errors).toHaveLength(1);

--- a/src/client.ts
+++ b/src/client.ts
@@ -286,6 +286,7 @@ export const initClientFetcher =
 		const requestContext = {
 			operationName: request.operationName,
 			documentId: request.documentId,
+			query: request.query,
 			variables: request.variables,
 		};
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -72,6 +72,8 @@ export type Logger = {
 export type RequestContext = {
 	operationName: string;
 	documentId?: string;
+	/** The GraphQL query string, for logging/diagnostics. */
+	query?: string;
 	variables: unknown;
 };
 


### PR DESCRIPTION
Expose the GraphQL query string on RequestContext so onGraphQLErrors and
onRequestError callbacks can log the actual query for diagnostics, not just
operationName/documentId. Additive; existing callbacks unaffected.
